### PR TITLE
Fix image modal and improve photo handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ korzysta z Firebase do przechowywania danych i obsługi logowania.
 ## Bezpieczeństwo
 
 * Dane wprowadzane przez użytkownika są sanitizowane przed wstawieniem do DOM.
-* Otwarcie podglądu zdjęć wykorzystuje atrybuty `noopener` i `noreferrer`.
+* Zdjęcia są wyświetlane w lekkim oknie modalnym z możliwością zamknięcia klawiszem Esc.
+* Miniatury wykorzystują `loading="lazy"`, a pliki są wstępnie kompresowane przed zapisem.
 * Usunięto logi debugowania zawierające potencjalnie wrażliwe informacje.
 
 Projekt nie posiada jeszcze zautomatyzowanych testów.

--- a/add-application.html
+++ b/add-application.html
@@ -506,11 +506,29 @@
         };
 
 
-        // Base64 image conversion utility
+        // Base64 image conversion utility with basic compression
         function convertFileToBase64(file) {
             return new Promise((resolve, reject) => {
                 const reader = new FileReader();
-                reader.onload = () => resolve(reader.result);
+                reader.onload = () => {
+                    const img = new Image();
+                    img.onload = () => {
+                        const MAX_DIMENSION = 1280;
+                        let { width, height } = img;
+                        if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+                            const scale = Math.min(MAX_DIMENSION / width, MAX_DIMENSION / height);
+                            width = Math.round(width * scale);
+                            height = Math.round(height * scale);
+                        }
+                        const canvas = document.createElement('canvas');
+                        canvas.width = width;
+                        canvas.height = height;
+                        canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+                        resolve(canvas.toDataURL('image/jpeg', 0.85));
+                    };
+                    img.onerror = error => reject(error);
+                    img.src = reader.result;
+                };
                 reader.onerror = error => reject(error);
                 reader.readAsDataURL(file);
             });
@@ -543,12 +561,20 @@
                 img.src = src;
                 img.alt = alt;
                 modal.classList.add('active');
+                document.addEventListener('keydown', escListener);
             }
         }
 
         function closeImageModal() {
             const modal = document.getElementById('imageModal');
             if (modal) modal.classList.remove('active');
+            document.removeEventListener('keydown', escListener);
+        }
+
+        function escListener(e) {
+            if (e.key === 'Escape') {
+                closeImageModal();
+            }
         }
 
         const imageModalEl = document.getElementById('imageModal');
@@ -607,6 +633,7 @@
                 img.src = url;
                 img.className = 'image-preview';
                 img.alt = `Preview ${index + 1}`;
+                img.loading = 'lazy';
                 img.title = `Zdjęcie ${index + 1} - kliknij aby powiększyć`;
                 img.style.cursor = 'pointer';
 

--- a/index.html
+++ b/index.html
@@ -1006,12 +1006,20 @@
                     img.src = src;
                     img.alt = alt;
                     modal.classList.add('active');
+                    document.addEventListener('keydown', escListener);
                 }
             }
 
             function closeImageModal() {
                 const modal = document.getElementById('imageModal');
                 if (modal) modal.classList.remove('active');
+                document.removeEventListener('keydown', escListener);
+            }
+
+            function escListener(e) {
+                if (e.key === 'Escape') {
+                    closeImageModal();
+                }
             }
 
             // Event listener for the return button

--- a/main.js
+++ b/main.js
@@ -86,6 +86,7 @@ function showImagesPreview(images) {;
             return;
         }
 
+        img.loading = 'lazy';
         img.style.maxWidth = '80px';
         img.style.maxHeight = '80px';
         img.style.borderRadius = '6px';


### PR DESCRIPTION
## Summary
- compress images on upload to reduce size
- load preview images lazily
- allow closing the preview modal with `Esc`
- update README to describe new behaviour

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d80b104748330a9e2e57ffaf132cc