### PR TITLE
Add salary range support

### DIFF
--- a/add-application.html
+++ b/add-application.html
@@ -373,9 +373,25 @@
             <div class="salary-group">
                 <div class="salary-main">
                     <div class="form-group">
-                        <label for="wynagrodzenie"><i class="fas fa-money-bill-wave"></i> Wynagrodzenie</label>
-                        <input type="number" id="wynagrodzenie" name="wynagrodzenie" min="0" step="any" required
+                        <label for="salaryMode"><i class="fas fa-money-bill-wave"></i> Wynagrodzenie</label>
+                        <select id="salaryMode" name="salaryMode">
+                            <option value="single">Całkowita kwota</option>
+                            <option value="range">Widełki</option>
+                        </select>
+                    </div>
+                    <div class="form-group" id="salarySingle">
+                        <label for="wynagrodzenie">Kwota</label>
+                        <input type="number" id="wynagrodzenie" name="wynagrodzenie" min="0" step="any"
                             placeholder="np. 8000">
+                    </div>
+                    <div class="form-group" id="salaryRange" style="display:none;">
+                        <label>Widełki</label>
+                        <div style="display:flex;gap:0.5em;">
+                            <input type="number" id="wynagrodzenieOd" name="wynagrodzenieOd" min="0" step="any"
+                                placeholder="od">
+                            <input type="number" id="wynagrodzenieDo" name="wynagrodzenieDo" min="0" step="any"
+                                placeholder="do">
+                        </div>
                     </div>
                 </div>
                 <div class="salary-currency">

--- a/add-application.js
+++ b/add-application.js
@@ -190,6 +190,18 @@
             validateLettersOnly(this);
         });
 
+        document.getElementById('salaryMode').addEventListener('change', function() {
+            const mode = this.value;
+            const single = document.getElementById('salarySingle');
+            const range = document.getElementById('salaryRange');
+            single.style.display = mode === 'single' ? 'block' : 'none';
+            range.style.display = mode === 'range' ? 'block' : 'none';
+            document.getElementById('wynagrodzenie').required = mode === 'single';
+            document.getElementById('wynagrodzenieOd').required = mode === 'range';
+            document.getElementById('wynagrodzenieDo').required = mode === 'range';
+        });
+        document.getElementById('salaryMode').dispatchEvent(new Event('change'));
+
         // Upload images using Base64 encoding
         async function uploadImages() {
             if (selectedFiles.length === 0) {;
@@ -257,7 +269,10 @@
             const firma = document.getElementById('firma').value;
             const data = document.getElementById('data').value;
             const status = document.getElementById('status').value;
+            const salaryMode = document.getElementById('salaryMode').value;
             const wynagrodzenie = document.getElementById('wynagrodzenie').value;
+            const wynagrodzenieOd = document.getElementById('wynagrodzenieOd').value;
+            const wynagrodzenieDo = document.getElementById('wynagrodzenieDo').value;
             const waluta = document.getElementById('waluta').value;
             const wynRodzaj = document.getElementById('wynRodzaj').value;
             const tryb = document.getElementById('tryb').value;
@@ -299,6 +314,7 @@
                     umowa,
                     waluta,
                     wynRodzaj,
+                    salaryMode,
                     statusHistory: [{
                         status: status,
                         date: data
@@ -310,7 +326,12 @@
                 };
 
                 // Dodaj opcjonalne pola tylko jeśli są wypełnione
-                applicationData.wynagrodzenie = parseFloat(wynagrodzenie);
+                if (salaryMode === 'single' && wynagrodzenie) {
+                    applicationData.wynagrodzenie = parseFloat(wynagrodzenie);
+                } else if (salaryMode === 'range') {
+                    if (wynagrodzenieOd) applicationData.wynagrodzenieOd = parseFloat(wynagrodzenieOd);
+                    if (wynagrodzenieDo) applicationData.wynagrodzenieDo = parseFloat(wynagrodzenieDo);
+                }
                 if (kontakt) applicationData.kontakt = kontakt;
                 if (link) applicationData.link = link;
                 if (notatki) applicationData.notatki = notatki;
@@ -359,6 +380,7 @@
                                 umowa,
                                 waluta,
                                 wynRodzaj,
+                                salaryMode,
                                 statusHistory: [{
                                     status: status,
                                     date: data
@@ -368,9 +390,14 @@
                                 userId: user.uid,
                                 createdAt: serverTimestamp()
                             };
-                            
+
                             // Add optional fields
-                            applicationData.wynagrodzenie = parseFloat(wynagrodzenie);
+                            if (salaryMode === 'single' && wynagrodzenie) {
+                                applicationData.wynagrodzenie = parseFloat(wynagrodzenie);
+                            } else if (salaryMode === 'range') {
+                                if (wynagrodzenieOd) applicationData.wynagrodzenieOd = parseFloat(wynagrodzenieOd);
+                                if (wynagrodzenieDo) applicationData.wynagrodzenieDo = parseFloat(wynagrodzenieDo);
+                            }
                             if (kontakt) applicationData.kontakt = kontakt;
                             if (link) applicationData.link = link;
                             if (notatki) applicationData.notatki = notatki;

--- a/index.html
+++ b/index.html
@@ -579,10 +579,26 @@
                         <div class="salary-group">
                             <div class="salary-main">
                                 <div class="form-group">
-                                    <label for="wynagrodzenie"><i class="fas fa-money-bill-wave"></i>
+                                    <label for="salaryMode"><i class="fas fa-money-bill-wave"></i>
                                         Wynagrodzenie</label>
+                                    <select id="salaryMode" name="salaryMode">
+                                        <option value="single">Całkowita kwota</option>
+                                        <option value="range">Widełki</option>
+                                    </select>
+                                </div>
+                                <div class="form-group" id="salarySingle">
+                                    <label for="wynagrodzenie">Kwota</label>
                                     <input type="number" id="wynagrodzenie" name="wynagrodzenie" min="0" step="any"
                                         placeholder="np. 8000">
+                                </div>
+                                <div class="form-group" id="salaryRange" style="display:none;">
+                                    <label>Widełki</label>
+                                    <div style="display:flex;gap:0.5em;">
+                                        <input type="number" id="wynagrodzenieOd" name="wynagrodzenieOd" min="0" step="any"
+                                            placeholder="od">
+                                        <input type="number" id="wynagrodzenieDo" name="wynagrodzenieDo" min="0" step="any"
+                                            placeholder="do">
+                                    </div>
                                 </div>
                             </div>
                             <div class="salary-currency">

--- a/main.js
+++ b/main.js
@@ -252,11 +252,13 @@ function loadFavorites() {
         querySnapshot.forEach((doc) => {
             const app = doc.data();
             let wynagrodzenieText = "";
-            if (app.wynagrodzenie) {
+            if (app.wynagrodzenieOd != null && app.wynagrodzenieDo != null) {
+                wynagrodzenieText = `${app.wynagrodzenieOd}-${app.wynagrodzenieDo} ${app.waluta || "PLN"}`;
+            } else if (app.wynagrodzenie) {
                 wynagrodzenieText = `${app.wynagrodzenie} ${app.waluta || "PLN"}`;
-                if (app.wynRodzaj) {
-                    wynagrodzenieText += ` ${app.wynRodzaj}`;
-                }
+            }
+            if (wynagrodzenieText && app.wynRodzaj) {
+                wynagrodzenieText += ` ${app.wynRodzaj}`;
             }
 
             html += `
@@ -522,11 +524,13 @@ function loadApplications(filters = {}, showArchived = false, sortOrder = 'desc'
             }
 
             let wynagrodzenieCell = "";
-            if (app.wynagrodzenie) {
+            if (app.wynagrodzenieOd != null && app.wynagrodzenieDo != null) {
+                wynagrodzenieCell = `${app.wynagrodzenieOd}-${app.wynagrodzenieDo} ${app.waluta || "PLN"}`;
+            } else if (app.wynagrodzenie) {
                 wynagrodzenieCell = app.wynagrodzenie + " " + (app.waluta || "PLN");
-                if (app.wynRodzaj) {
-                    wynagrodzenieCell += " " + app.wynRodzaj;
-                }
+            }
+            if (wynagrodzenieCell && app.wynRodzaj) {
+                wynagrodzenieCell += " " + app.wynRodzaj;
             }
 
             // Funkcje do konwersji wartości na czytelny tekst


### PR DESCRIPTION
## Summary
- extend salary input with a mode selector (kwota/widełki)
- support salary ranges when submitting an application
- show ranges in the application list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f0bbe60448330b6c5d1136abf75fe